### PR TITLE
dereference deprecated default_sidebars

### DIFF
--- a/sphinxcontrib/versioning/sphinx_.py
+++ b/sphinxcontrib/versioning/sphinx_.py
@@ -57,7 +57,7 @@ class EventHandlers(object):
 
         # Add versions.html to sidebar.
         if '**' not in app.config.html_sidebars:
-            app.config.html_sidebars['**'] = StandaloneHTMLBuilder.default_sidebars + ['versions.html']
+            app.config.html_sidebars['**'] = ['versions.html']
         elif 'versions.html' not in app.config.html_sidebars['**']:
             app.config.html_sidebars['**'].append('versions.html')
 


### PR DESCRIPTION
StandaloneHTMLBuilder.default_sidebars was removed in sphinx ~1.6.

https://github.com/sphinx-doc/sphinx/commit/e8e63b1e9968abbaff46ddd7917d2b53cb505276#diff-c17608ed63bfe1714c6befb9d4201fee

Fixes #39 